### PR TITLE
fix hdf upload attempt error

### DIFF
--- a/cumulus/process.py
+++ b/cumulus/process.py
@@ -155,6 +155,8 @@ class Process(object):
             remote = {}
             for f in granule:
                 fname = granule[f]
+                if 'hdf' in fname:
+                    continue # skip hdf which is already in s3
                 urls = self.urls(fname)
                 try:
                     if urls['s3'] is not None:


### PR DESCRIPTION
prevents error on attempt to upload hdf to s3 (hdf is typically not in /tmp/, and either way already on s3)