### PR TITLE
Update CircleCI to support Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,14 +129,15 @@ jobs:
 
 workflows:
   version: 2
-  build_test_publish:
+  build_test_38_deploy:
+    jobs:
+      - install_and_test_38
+  build_test_36_deploy:
     jobs:
       - install_and_test_36
-      - install_and_test_38
       - deploy:
           requires:
             - install_and_test_36
-            - install_and_test_38
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,13 @@ references:
       - name: localstack
         image: localstack/localstack
     working_dir: ~/project
+  
+  container_python38: &container_python38
+    docker:
+      - image: circleci/python:3.8.1
+      - name: localstack
+        image: localstack/localstack:0.11.5
+    working_directory: ~/repo
 
   restore_repo: &restore_repo
     restore_cache:
@@ -26,13 +33,6 @@ references:
       keys:
         - v0-dependencies36-{{ checksum "requirements.txt" }}
         - v0-dependencies36
-
-  container_python38: &container_python38
-    docker:
-      - image: circleci/python:3.8.1
-      - name: localstack
-        image: localstack/localstack:0.11.5
-    working_directory: ~/repo
 
   restore_dependencies38: &restore_dependencies38
     restore_cache:
@@ -71,33 +71,33 @@ jobs:
             nosetests -v --with-coverage --cover-package cumulus_process
 
   install_and_test_38:
-  <<: *container_python38
-  steps:
-    - *restore_repo
-    - checkout
-    - *save_repo
-    - *restore_dependencies38
-    - run:
-        name: Install virtualenv
-        command: pip install --user virtualenv
-    - run:
-        name: Install dependencies
-        command: |
-          ~/.local/bin/virtualenv ~/venv38
-          . ~/venv36/bin/activate
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-    - save_cache:
-        key: v0-dependencies38-{{ checksum "requirements.txt"}}
-        paths:
-          - ~/venv38
-    - run :
-        name: Run tests
-        environment:
-          LOCALSTACK_HOST: localstack
-        command: |
-          . ~/venv38/bin/activate
-          nosetests -v --with-coverage --cover-package cumulus_process
+    <<: *container_python38
+    steps:
+      - *restore_repo
+      - checkout
+      - *save_repo
+      - *restore_dependencies38
+      - run:
+          name: Install virtualenv
+          command: pip install --user virtualenv
+      - run:
+          name: Install dependencies
+          command: |
+            ~/.local/bin/virtualenv ~/venv38
+            . ~/venv36/bin/activate
+            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
+      - save_cache:
+          key: v0-dependencies38-{{ checksum "requirements.txt"}}
+          paths:
+            - ~/venv38
+      - run :
+          name: Run tests
+          environment:
+            LOCALSTACK_HOST: localstack
+          command: |
+            . ~/venv38/bin/activate
+            nosetests -v --with-coverage --cover-package cumulus_process
 
   deploy:
     <<: *container_python36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           name: Install dependencies
           command: |
             ~/.local/bin/virtualenv ~/venv38
-            . ~/venv36/bin/activate
+            . ~/venv38/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,19 @@ references:
         - v0-dependencies36-{{ checksum "requirements.txt" }}
         - v0-dependencies36
 
+  container_python38: &container_python38
+    docker:
+      - image: circleci/python:3.8.1
+      - name: localstack
+        image: localstack/localstack:0.11.5
+    working_directory: ~/repo
+
+  restore_dependencies38: &restore_dependencies38
+    restore_cache:
+      keys:
+        - v0-dependencies38-{{ checksum "requirements.txt" }}
+        - v0-dependencies38
+
 jobs:
   install_and_test_36:
     <<: *container_python36
@@ -55,6 +68,35 @@ jobs:
             LOCALSTACK_HOST: localstack
           command: |
             . ~/venv36/bin/activate
+            nosetests -v --with-coverage --cover-package cumulus_process
+
+    install_and_test_38:
+    <<: *container_python38
+    steps:
+      - *restore_repo
+      - checkout
+      - *save_repo
+      - *restore_dependencies38
+      - run:
+          name: Install virtualenv
+          command: pip install --user virtualenv
+      - run:
+          name: Install dependencies
+          command: |
+            ~/.local/bin/virtualenv ~/venv38
+            . ~/venv36/bin/activate
+            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
+      - save_cache:
+          key: v0-dependencies38-{{ checksum "requirements.txt"}}
+          paths:
+            - ~/venv38
+      - run :
+          name: Run tests
+          environment:
+            LOCALSTACK_HOST: localstack
+          command: |
+            . ~/venv38/bin/activate
             nosetests -v --with-coverage --cover-package cumulus_process
 
   deploy:
@@ -96,3 +138,6 @@ workflows:
           filters:
             branches:
               only: master
+  build_test_38_deploy:
+    jobs:
+      - install_and_test_38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,15 +129,15 @@ jobs:
 
 workflows:
   version: 2
+  build_test_36:
+    jobs:
+      - install_and_test_36
   build_test_38_deploy:
     jobs:
       - install_and_test_38
-  build_test_36_deploy:
-    jobs:
-      - install_and_test_36
       - deploy:
           requires:
-            - install_and_test_36
+            - install_and_test_38
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            ~/.local/bin/virtualenv ~/venv38
+            /usr/local/bin/virtualenv ~/venv38
             . ~/venv38/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ references:
       - name: localstack
         image: localstack/localstack
     working_dir: ~/project
-  
+
   container_python38: &container_python38
     docker:
       - image: circleci/python:3.8.1
@@ -129,15 +129,14 @@ jobs:
 
 workflows:
   version: 2
-  build_test_36_deploy:
+  build_test_publish:
     jobs:
       - install_and_test_36
+      - install_and_test_38
       - deploy:
           requires:
             - install_and_test_36
+            - install_and_test_38
           filters:
             branches:
               only: master
-  build_test_38_deploy:
-    jobs:
-      - install_and_test_38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,34 +70,34 @@ jobs:
             . ~/venv36/bin/activate
             nosetests -v --with-coverage --cover-package cumulus_process
 
-    install_and_test_38:
-    <<: *container_python38
-    steps:
-      - *restore_repo
-      - checkout
-      - *save_repo
-      - *restore_dependencies38
-      - run:
-          name: Install virtualenv
-          command: pip install --user virtualenv
-      - run:
-          name: Install dependencies
-          command: |
-            ~/.local/bin/virtualenv ~/venv38
-            . ~/venv36/bin/activate
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-      - save_cache:
-          key: v0-dependencies38-{{ checksum "requirements.txt"}}
-          paths:
-            - ~/venv38
-      - run :
-          name: Run tests
-          environment:
-            LOCALSTACK_HOST: localstack
-          command: |
-            . ~/venv38/bin/activate
-            nosetests -v --with-coverage --cover-package cumulus_process
+  install_and_test_38:
+  <<: *container_python38
+  steps:
+    - *restore_repo
+    - checkout
+    - *save_repo
+    - *restore_dependencies38
+    - run:
+        name: Install virtualenv
+        command: pip install --user virtualenv
+    - run:
+        name: Install dependencies
+        command: |
+          ~/.local/bin/virtualenv ~/venv38
+          . ~/venv36/bin/activate
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+    - save_cache:
+        key: v0-dependencies38-{{ checksum "requirements.txt"}}
+        paths:
+          - ~/venv38
+    - run :
+        name: Run tests
+        environment:
+          LOCALSTACK_HOST: localstack
+        command: |
+          . ~/venv38/bin/activate
+          nosetests -v --with-coverage --cover-package cumulus_process
 
   deploy:
     <<: *container_python36


### PR DESCRIPTION
This updates the Circle CI script to support Python 3.8 (and retain the deprecated 3.6 build). I used a separate workflow for 3.8 thinking that's easier to decouple when we eventually remove Python 3.8 but I'm not sure there's a huge benefit either way so open to discussion.

This should be checked by someone familiar with the Python build process and Circle CI workflows. I'm asserting that this builds both Python 3.6 + 3.8 versions, then publishes to PyPi.