### PR TITLE
Fix incorrect path in Python 3.8 CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,11 +101,11 @@ jobs:
             nosetests -v --with-coverage --cover-package cumulus_process
 
   deploy:
-    <<: *container_python36
+    <<: *container_python38
     steps:
       - checkout
       - *restore_repo
-      - *restore_dependencies36
+      - *restore_dependencies38
       - add_ssh_keys:
           fingerprints:
             - "3a:8d:f7:0d:de:79:98:bc:56:10:83:ab:c1:ee:3d:30"
@@ -123,7 +123,7 @@ jobs:
       - run:
           name: Deploy to PyPi
           command: |
-            . ~/venv36/bin/activate
+            . ~/venv38/bin/activate
             pip install twine
             python setup.py sdist
             twine upload --skip-existing --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ references:
     docker:
       - image: circleci/python:3.8.1
       - name: localstack
-        image: localstack/localstack:0.11.5
-    working_directory: ~/repo
+        image: localstack/localstack
+    working_directory: ~/project
 
   restore_repo: &restore_repo
     restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 # Python CircleCI 2.0 configuration file
+
 version: 2
 references:
   container_python36: &container_python36


### PR DESCRIPTION
After merging https://github.com/nasa/cumulus-process-py/pull/145, tests on master began to fail. I opened this branch without changes and the failures were replicable. Updating the path in the Python 3.8 container _appears_ to fix CI. This could be due to a caching problem caused by incorrect paths.

Failing build on main: https://app.circleci.com/pipelines/github/nasa/cumulus-process-py/79/workflows/7c8cceee-d7cb-4a71-aa30-a758f386264a